### PR TITLE
Add support for a non 0 exit code if lock was never retrieved

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Use `cronlocker --help` to get the following output:
 Usage of ./cronlocker:
   -endpoint string
       endpoint (default "http://localhost:8500")
+  -failwithoutlock
+      Exists with status code 1 if the lock was not received within lockwaittime
   -key string
       key to monitor, e.g. cronjobs/any_service/cron_name (default "none")
   -lockwaittime int

--- a/main.go
+++ b/main.go
@@ -14,6 +14,11 @@ var (
 		500,
 		"Configures the wait time for a lock in milliseconds",
 	)
+	failOnLockWaitExpiration = flag.Bool(
+		"failwithoutlock",
+		false,
+		"Exists with status code 1 if the lock was not received within lockwaittime",
+	)
 	minLockTimeMS = flag.Int(
 		"minlocktime",
 		5000,
@@ -52,6 +57,7 @@ func main() {
 		time.Duration(*lockWaitTimeMS)*time.Millisecond,
 		time.Duration(*minLockTimeMS)*time.Millisecond,
 		time.Duration(*maxExecutionTimeMS)*time.Millisecond,
+		*failOnLockWaitExpiration,
 	)
 	if err != nil {
 		log.Fatalf("%v", err)


### PR DESCRIPTION
When the flag is given, it will return exit code 1 for cases where the lockwaittime has passed